### PR TITLE
Expose version number for bundled jquery.js, for easy use of a CDN

### DIFF
--- a/lib/generators/jquery/install/install_generator.rb
+++ b/lib/generators/jquery/install/install_generator.rb
@@ -3,11 +3,8 @@ require 'rails'
 module Jquery
   module Generators
     class InstallGenerator < ::Rails::Generators::Base
-      @@jquery_version     = "1.6.1"
-      @@jquery_ui_version  = "1.8.12"
-      @@jquery_ujs_version = "dad6982dc592686677e6845e681233c40d2ead27"
 
-      desc "This generator installs jQuery #{@@jquery_version}, jQuery-ujs, and (optionally) jQuery UI #{@@jquery_ui_version}"
+      desc "This generator installs jQuery #{Jquery::Rails::JQUERY_VERSION}, jQuery-ujs, and (optionally) jQuery UI #{Jquery::Rails::JQUERY_UI_VERSION}"
       class_option :ui, :type => :boolean, :default => false, :desc => "Include jQueryUI"
       source_root File.expand_path('../../../../../vendor/assets/javascripts', __FILE__)
 
@@ -18,21 +15,21 @@ module Jquery
       end
 
       def copy_jquery
-        say_status("copying", "jQuery (#{@@jquery_version})", :green)
+        say_status("copying", "jQuery (#{Jquery::Rails::JQUERY_VERSION})", :green)
         copy_file "jquery.js", "public/javascripts/jquery.js"
         copy_file "jquery.min.js", "public/javascripts/jquery.min.js"
       end
 
       def copy_jquery_ui
         if options.ui?
-          say_status("copying", "jQuery UI (#{@@jquery_ui_version})", :green)
+          say_status("copying", "jQuery UI (#{Jquery::Rails::JQUERY_UI_VERSION})", :green)
           copy_file "jquery-ui.js", "public/javascripts/jquery-ui.js"
           copy_file "jquery-ui.min.js", "public/javascripts/jquery-ui.min.js"
         end
       end
 
       def copy_ujs_driver
-        say_status("copying", "jQuery UJS adapter (#{@@jquery_ujs_version[0..5]})", :green)
+        say_status("copying", "jQuery UJS adapter (#{Jquery::Rails::JQUERY_UJS_VERSION[0..5]})", :green)
         remove_file "public/javascripts/rails.js"
         copy_file "jquery_ujs.js", "public/javascripts/jquery_ujs.js"
       end

--- a/lib/jquery/rails.rb
+++ b/lib/jquery/rails.rb
@@ -7,5 +7,6 @@ module Jquery
     else
       require 'jquery/rails/engine'
     end
+    require 'jquery/rails/version'
   end
 end

--- a/lib/jquery/rails/version.rb
+++ b/lib/jquery/rails/version.rb
@@ -1,5 +1,8 @@
 module Jquery
   module Rails
     VERSION = "1.0.9"
+    JQUERY_VERSION = "1.6.1"
+    JQUERY_UI_VERSION  = "1.8.12"
+    JQUERY_UJS_VERSION = "dad6982dc592686677e6845e681233c40d2ead27"
   end
 end


### PR DESCRIPTION
On production sites, it's nice to use an offsite CDN to serve
jquery.js, and there's a nice technique for seamlessly falling back to
the local bundled jquery.js if the CDN is unavailable:

http://weblogs.asp.net/jgalloway/archive/2010/01/21/using-cdn-hosted-jquery-with-a-local-fall-back-copy.aspx.

To ensure that the CDN jquery.js version matches that bundled with
jquery-rails, it's necessary to programatically access the bundled
version number. This commit allows users to do the following, by
ensuring that the jquery version is no longer hidden away in the
install generator:

```
= javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/#{Jquery::Rails::JQUERY_VERSION}/jquery.min.js"
:javascript
  if (typeof jQuery == 'undefined') {
    document.write(unescape(#{URI.escape(javascript_include_tag('jquery')).to_json}));
  }
```
