### PR TITLE
javascript_expansions[:defaults] in config/application.rb overwrite amendments made by railtie.rb

### DIFF
--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -3,7 +3,7 @@ module Jquery
   module Rails
 
     class Railtie < ::Rails::Railtie
-      config.before_configuration do
+      config.before_initialize do
         require "jquery/assert_select" if ::Rails.env.test?
 
         if ::Rails.root.join("public/javascripts/jquery-ui.min.js").exist?


### PR DESCRIPTION
Changed railtie to amend configuration after Rails has parsed config/application.rb.
Tested with 3.0.7.
This will adversely affect projects where the jquery scripts have been added in the application.rb, any scripts added to default there will be added in addition to the scripts added by the railtie. Hopefully a reasonable trade off as currently the railtie is ignored if javascript_expansions[:defaults] is set in application.rb.
