### PR TITLE
Properly handle escaped single quotes in assert_select.rb

### DIFF
--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -84,6 +84,7 @@ module ActionDispatch
       def unescape_js(js_string)
         # js encodes double quotes and line breaks.
         unescaped= js_string.gsub('\"', '"')
+        unescaped.gsub!('\\\'', "'")
         unescaped.gsub!(/\\\//, '/')
         unescaped.gsub!('\n', "\n")
         unescaped.gsub!('\076', '>')


### PR DESCRIPTION
Hey guys - apologies in advance if I'm sending this to the wrong repo, but it looks like you're upstream from Sam Ruby on assert_select_jquery.  This is a small patch to properly handle escaped single quotes that are passed to assert_select_jquery.

HAML will sometimes generate attributes that are single-quoted, and ActionView::Helpers::JavaScriptHelper#escape_javascript will escape them.  If assert_select_jquery doesn't unescape them, they're passed along in escaped form to HTML::Document#new, which will then fail to parse properly, and cause the subsequent select to fail.

Thanks!  Let me know if you need anything else done on this.
