### PR TITLE
assert_select_jquery without a block returns "No JQuery call matches #{opts.inspect}" even though it did find a match

### DIFF
--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -52,7 +52,7 @@ module ActionDispatch
 
         pattern = "\\.#{jquery_method || '\\w+'}\\("
         pattern = "#{pattern}['\"]#{jquery_opt}['\"],?\\s*" if jquery_opt
-        pattern = "#{pattern}#{PATTERN_HTML}" if block
+        pattern = "#{pattern}#{PATTERN_HTML}"
         pattern = "(?:jQuery|\\$)\\(['\"]#{id}['\"]\\)#{pattern}" if id
 
         fragments = []


### PR DESCRIPTION
Hi guys,

first time sending a pull request. I hope this works..

This small change seems to fix issue 14 I encountered when using assert_select_jquery as outlined in the issue description
