### PR TITLE
Default accept extensions change

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -133,7 +133,7 @@
           // stopping the "ajax:beforeSend" event will cancel the ajax request
           beforeSend: function(xhr, settings) {
             if (settings.dataType === undefined) {
-              xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts.script);
+              xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts._default);
             }
             return rails.fire(element, 'ajax:beforeSend', [xhr, settings]);
           },


### PR DESCRIPTION
If i not specify any data-type, and my active_scaffold list build automatically, my request header ask for text/javascript, and my application, by default (i not specify any format) response to that request with header response text/javascript, BUT generate an text/html content.

So i think, if developer don't specify any data-type it needs to be _default, ie any (*/*)
