### PR TITLE
UJS data-remote support does not work in IE

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -129,6 +129,12 @@
           data = element.data('params') || null;
         }
 
+        // Since IE will send a DELETE/PUT to the redirected URL
+        if(method && method.toLowerCase() !== 'get'){
+          data = data + "&" + "_method=" + method;
+          method = 'POST';
+        }
+
         options = {
           type: method || 'GET', data: data, dataType: dataType, crossDomain: crossDomain,
           // stopping the "ajax:beforeSend" event will cancel the ajax request
@@ -270,7 +276,7 @@
       element.data('ujs:enable-with', element.html()); // store enabled state
       element.html(element.data('disable-with')); // set to disabled state
       element.bind('click.railsDisable', function(e) { // prevent further clicking
-        return rails.stopEverything(e)
+        return rails.stopEverything(e);
       });
     },
 


### PR DESCRIPTION
Standard practice for browsers over the years is that redirects from POST requests are followed with a GET request.

This works great in all modern browsers, except IE. Not only does IE send a real DELETE/PUT request, it also follows the redirect with another DELETE/PUT. If that redirect points to another resource, you can get a dangerous cascading effect (or just 404 routing errors).

This patch remedies this issue by performing an AJAX post with a '_method' param on a DELETE/PUT request and always uses a POST.
