### PR TITLE
should not rely on beta anymore, that would conflict with specific rails 3.2.x version

### DIFF
--- a/jquery-rails.gemspec
+++ b/jquery-rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "jquery-rails"
 
-  s.add_dependency "railties", ">= 3.2.0.beta", "< 5.0"
+  s.add_dependency "railties", ">= 3.2.0", "< 5.0"
   s.add_dependency "thor",     "~> 0.14"
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
something like:

Bundler could not find compatible versions for gem "railties":
  In Gemfile:
    rails (= 3.2.1) ruby depends on
      railties (= 3.2.1) ruby

```
jquery-rails (= 2.0.0) ruby depends on
  railties (3.2.2.rc1)
```
