### PR TITLE
 - fixes 'NameError: uninitialized constant Jquery::Rails' when doing ge...

### DIFF
--- a/lib/generators/jquery/install/install_generator.rb
+++ b/lib/generators/jquery/install/install_generator.rb
@@ -2,6 +2,7 @@ require 'rails'
 
 # Supply generator for Rails 3.0.x or if asset pipeline is not enabled
 if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
+  require 'jquery-rails'
   module Jquery
     module Generators
       class InstallGenerator < ::Rails::Generators::Base


### PR DESCRIPTION
...nerate jquery:install in rails 3.0.12 under jruby
