### PR TITLE
Change .delegate to .on to fix IE8 issues

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -323,11 +323,11 @@
 
     $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
 
-    $(document).delegate(rails.linkDisableSelector, 'ajax:complete', function() {
+    $(document).on(rails.linkDisableSelector, 'ajax:complete', function() {
         rails.enableElement($(this));
     });
 
-    $(document).delegate(rails.linkClickSelector, 'click.rails', function(e) {
+    $(document).on(rails.linkClickSelector, 'click.rails', function(e) {
       var link = $(this), method = link.data('method'), data = link.data('params');
       if (!rails.allowAction(link)) return rails.stopEverything(e);
 
@@ -351,7 +351,7 @@
       }
     });
 
-    $(document).delegate(rails.inputChangeSelector, 'change.rails', function(e) {
+    $(document).on(rails.inputChangeSelector, 'change.rails', function(e) {
       var link = $(this);
       if (!rails.allowAction(link)) return rails.stopEverything(e);
 
@@ -359,7 +359,7 @@
       return false;
     });
 
-    $(document).delegate(rails.formSubmitSelector, 'submit.rails', function(e) {
+    $(document).on(rails.formSubmitSelector, 'submit.rails', function(e) {
       var form = $(this),
         remote = form.data('remote') !== undefined,
         blankRequiredInputs = rails.blankInputs(form, rails.requiredInputSelector),
@@ -398,7 +398,7 @@
       }
     });
 
-    $(document).delegate(rails.formInputClickSelector, 'click.rails', function(event) {
+    $(document).on(rails.formInputClickSelector, 'click.rails', function(event) {
       var button = $(this);
 
       if (!rails.allowAction(button)) return rails.stopEverything(event);
@@ -410,11 +410,11 @@
       button.closest('form').data('ujs:submit-button', data);
     });
 
-    $(document).delegate(rails.formSubmitSelector, 'ajax:beforeSend.rails', function(event) {
+    $(document).on(rails.formSubmitSelector, 'ajax:beforeSend.rails', function(event) {
       if (this == event.target) rails.disableFormElements($(this));
     });
 
-    $(document).delegate(rails.formSubmitSelector, 'ajax:complete.rails', function(event) {
+    $(document).on(rails.formSubmitSelector, 'ajax:complete.rails', function(event) {
       if (this == event.target) rails.enableFormElements($(this));
     });
 


### PR DESCRIPTION
This has been reported in #67 and #69. 

This pull request changes the `.delegate()` calls to `.on()` as of jQuery 1.7, `.delegate()` has been superseded by `.on()` and it fixes the IE8 performance issue.
