### PR TITLE
Add rails 3.1 version note to Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
     - created `rails:attachBindings` to allow for customization of $.rails object settings
     - created `ajax:send` event to provide access to jqXHR object from ajax requests
     - added support for `data-with-credentials`
+  - Lowered minimum rails dependency to Rails 3.1
 
 ## 2.0.2 (03 April 2012)
 


### PR DESCRIPTION
In version 2.0.3 rails min version was lowered to 3.1. I think this is
important enough of a change to be mentioned in the ChangeLog especially
as the previous versions note the min version being 3.2.
