### PR TITLE
Make minified versions of scripts included in production mode when asset pipeline is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In order to use the themed parts of jQuery UI, you will also need to supply [you
 
 This gem adds a single generator: `jquery:install`. Running the generator will remove any Prototype JS files you may happen to have, and copy jQuery and the jQuery-ujs driver for Rails (and optionally, jQuery UI) to the `public/javascripts` directory.
 
-This gem will also hook into the Rails configuration process, removing Prototype and adding jQuery to the javascript files included by the `javascript_include_tag(:defaults)` call. While this gem contains the minified and un-minified versions of jQuery and jQuery UI, only the minified versions are included in `:defaults`.
+This gem will also hook into the Rails configuration process, removing Prototype and adding jQuery to the javascript files included by the `javascript_include_tag(:defaults)` call. While this gem contains the minified and un-minified versions of jQuery and jQuery UI, only the minified versions will be included in the `:defaults` when Rails is run in `production` or `test` mode  (un-minified versions will be included when Rails is run in `development` mode).
 
 To invoke the generator, run:
 

--- a/lib/jquery/rails.rb
+++ b/lib/jquery/rails.rb
@@ -1,4 +1,8 @@
-require 'jquery/rails/engine'
+if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
+  require 'jquery/rails/railtie'
+else
+  require 'jquery/rails/engine'
+end
 require 'jquery/rails/version'
 
 module Jquery

--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -1,0 +1,25 @@
+# Used to ensure that Rails 3.0.x, as well as Rails >= 3.1 with asset pipeline disabled
+# get the minified version of the scripts included into the layout in production.
+module Jquery
+  module Rails
+
+    class Railtie < ::Rails::Railtie
+      config.before_configuration do
+
+        if ::Rails.root.join("public/javascripts/jquery-ui.min.js").exist?
+          jq_defaults = %w(jquery jquery-ui)
+          jq_defaults.map!{|a| a + ".min" } if ::Rails.env.production? || ::Rails.env.test?
+        else
+          jq_defaults = ::Rails.env.production? || ::Rails.env.test? ? %w(jquery.min) : %w(jquery)
+        end
+
+        # Merge the jQuery scripts, remove the Prototype defaults and finally add 'jquery_ujs'
+        # at the end, because load order is important
+        config.action_view.javascript_expansions[:defaults] -= PROTOTYPE_JS + ['rails']
+        config.action_view.javascript_expansions[:defaults] |= jq_defaults
+        config.action_view.javascript_expansions[:defaults] << 'jquery_ujs'
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The README file currently says:

> Rails 3.0 (or greater with asset pipeline disabled)
> ...
> While this gem contains the minified and un-minified versions of jQuery and jQuery UI, only the minified versions are included in :defaults.

This is not actually true anymore for the gem, at least not when this gem is used on an app running with Rails 3.0 (or greater with asset pipeline disabled).  This functionality was removed with [this commit](https://github.com/rails/jquery-rails/commit/84a3670769987cd20f5c6b19171cdc92905c7d43) (although I'm not entirely sure why).

I don't see a downside to re-enabling this functionality, as I know there are many rails developers out there who have yet to migrate their existing apps to use the asset pipeline.  Here is code that will re-enable functionality so that the minified versions of the scripts get added into the `:defaults` group when a Rails app is run in `production` or `test` mode (along with a modification to the documentation to inform the user of exactly how it works).
