### PR TITLE
Read jQuery and jQuery UI versions from libraries files

### DIFF
--- a/lib/jquery/rails/version.rb
+++ b/lib/jquery/rails/version.rb
@@ -1,8 +1,18 @@
 module Jquery
   module Rails
+    def self.read_version(file, pattern)
+      dir  = File.expand_path('../../../../vendor/assets/javascripts', __FILE__)
+      file = File.join(dir, file)
+      File.open(file) do |io|
+        match = io.read.match(pattern)
+        raise "Can't read version from #{file}" unless match
+        return match[1]
+      end
+    end
+
     VERSION = "2.2.0"
-    JQUERY_VERSION = "1.8.3"
-    JQUERY_UI_VERSION  = "1.9.2"
+    JQUERY_VERSION     = read_version('jquery.js', /jQuery [^\n]+ v([^\s]+)/)
+    JQUERY_UI_VERSION  = read_version('jquery-ui.js', /jQuery UI - v([^\s]+)/)
     JQUERY_UJS_VERSION = "bddff6a677edc54f00e48bde740b0b22d68deef6"
   end
 end


### PR DESCRIPTION
Prevent issue like #97, when we forget to update `JQUERY_VERSION`.
