### PR TITLE
attempt to trigger ajax events on replacement form if original form becomes detached

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -153,7 +153,9 @@
             return element;
 
           var id = element.attr('id');
-          return id ? $('#' + id) : $(document);
+          var replacement = $('#' + id);
+          
+          return replacement.length == 0 ? $(document) : replacement; 
         }
 
         options = {


### PR DESCRIPTION
Hi

This is a tweak to the problem indicated in:

https://github.com/rails/jquery-ujs/issues/223

I am taking this approach:
- ajax callback triggered inside rails-ujs
- see if the element used to initiate the ajax request is now detached
- if it is, look for an id attribute
- if there is an id attribute, look for an attached element with that id
- if there is an attached element with that id, trigger the event on that element
- otherwise fallback to trigger the events on $(document)

What do you think? 
