### PR TITLE
add license information to the gemspec

### DIFF
--- a/jquery-rails.gemspec
+++ b/jquery-rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.homepage    = "http://rubygems.org/gems/jquery-rails"
   s.summary     = "Use jQuery with Rails 3"
   s.description = "This gem provides jQuery and the jQuery-ujs driver for your Rails 3 application."
+  s.license     = "MIT"
 
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "jquery-rails"


### PR DESCRIPTION
This way we can get it when using rubygems.org API
