### PR TITLE
Don't require Rails

### DIFF
--- a/lib/jquery/rails.rb
+++ b/lib/jquery/rails.rb
@@ -1,6 +1,9 @@
-require 'jquery/assert_select' if ::Rails.env.test?
-require 'jquery/rails/engine' if ::Rails.version >= '3.1'
-require 'jquery/rails/railtie'
+if defined? ::Rails
+  require 'jquery/assert_select' if ::Rails.env.test?
+  require 'jquery/rails/engine' if ::Rails.version >= '3.1'
+  require 'jquery/rails/railtie'
+end
+
 require 'jquery/rails/version'
 
 module Jquery


### PR DESCRIPTION
Hi guys,

I work on https://github.com/middleman/middleman, and we use Sprockets to support JavaScript in a similar way to Rails. However, that can be weird when we use gems that provide JS to Sprockets without the Rails context.

Here's what causes the problem in jquery-rails:
https://github.com/rails/jquery-rails/blob/master/lib/jquery/rails.rb

Would it be possible for those lines to be conditional on the existence of the Rails module?
