### PR TITLE
Confirm message modifable in 'confirm' event.

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -209,11 +209,11 @@
       return false. The `confirm:complete` event is fired whether or not the user answered true or false to the dialog.
    */
     allowAction: function(element) {
-      var message = element.data('confirm'),
-          answer = false, callback;
-      if (!message) { return true; }
+      var message, answer = false, callback;
 
       if (rails.fire(element, 'confirm')) {
+        message = element.data('confirm');
+        if (!message) { return true; }
         answer = rails.confirm(message);
         callback = rails.fire(element, 'confirm:complete', [answer]);
       }


### PR DESCRIPTION
The confirm message can be modified during the 'confirm' event.

It can also be deleted so that the action occurs without the user beign
asked any confirmation.
