### PR TITLE
Don't set the CSRFProtection on GET requests

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -291,7 +291,7 @@
 
   };
 
-  $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
+  $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain && options.type !== 'GET' ) { rails.CSRFProtection(xhr); }});
 
   $(document).delegate(rails.linkDisableSelector, 'ajax:complete', function() {
       rails.enableElement($(this));


### PR DESCRIPTION
From the [Rails Security Guide](http://guides.rubyonrails.org/security.html) on CSRF:

> There are many other possibilities, including Ajax to attack the victim in the background. The solution to this is including a security token in **non-GET requests** which check on the server-side.
