### PR TITLE
Hopefully remove all traces of integrated jquery-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,17 +56,20 @@ jquery-ui-rails gem above.*
 
 ### Rails 3.0 (or greater with asset pipeline *disabled*)
 
-This gem adds a single generator: `jquery:install`. Running the generator will remove any Prototype JS files you may happen to have, and copy jQuery and the jQuery-ujs driver for Rails (and optionally, jQuery UI) to the `public/javascripts` directory.
+This gem adds a single generator: `jquery:install`. Running the generator will remove any Prototype JS files you may happen to have, and copy jQuery and the jQuery-ujs driver for Rails to the `public/javascripts` directory.
 
-This gem will also hook into the Rails configuration process, removing Prototype and adding jQuery to the javascript files included by the `javascript_include_tag(:defaults)` call. While this gem contains the minified and un-minified versions of jQuery and jQuery UI, only the minified versions will be included in the `:defaults` when Rails is run in `production` or `test` mode  (un-minified versions will be included when Rails is run in `development` mode).
+This gem will also hook into the Rails configuration process, removing Prototype and adding jQuery to the javascript files included by the `javascript_include_tag(:defaults)` call. While this gem contains the minified and un-minified versions of jQuery, only the minified versions will be included in the `:defaults` when Rails is run in `production` or `test` mode  (un-minified versions will be included when Rails is run in `development` mode).
 
 To invoke the generator, run:
 
 ```sh
-rails generate jquery:install #--ui to enable jQuery UI
+rails generate jquery:install
 ```
 
 You're done!
+
+*As of v3.0, jquery-rails no longer includes jQuery UI, you will need to
+install it by yourself as needed.*
 
 ## Contributing
 
@@ -74,7 +77,7 @@ Feel free to open an issue ticket if you find something that could be improved. 
 
 * If it's an issue pertaining to the jquery-ujs javascript, please report it to the [jquery-ujs project](https://github.com/rails/jquery-ujs).
 
-* If the jquery or jquery-ui scripts are outdated (i.e. maybe a new version of jquery was released yesterday), feel free to open an issue and prod us to get that thing updated. However, for security reasons, we won't be accepting pull requests with updated jquery or jquery-ui scripts.
+* If the jquery scripts are outdated (i.e. maybe a new version of jquery was released yesterday), feel free to open an issue and prod us to get that thing updated. However, for security reasons, we won't be accepting pull requests with updated jquery scripts.
 
 ## Acknowledgements
 

--- a/lib/generators/jquery/install/install_generator.rb
+++ b/lib/generators/jquery/install/install_generator.rb
@@ -6,8 +6,7 @@ if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
     module Generators
       class InstallGenerator < ::Rails::Generators::Base
 
-        desc "This generator installs jQuery #{Jquery::Rails::JQUERY_VERSION}, jQuery-ujs, and (optionally) jQuery UI #{Jquery::Rails::JQUERY_UI_VERSION}"
-        class_option :ui, :type => :boolean, :default => false, :desc => "Include jQueryUI"
+        desc "This generator installs jQuery #{Jquery::Rails::JQUERY_VERSION} and jQuery-ujs"
         source_root File.expand_path('../../../../../vendor/assets/javascripts', __FILE__)
 
         def remove_prototype
@@ -20,14 +19,6 @@ if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
           say_status("copying", "jQuery (#{Jquery::Rails::JQUERY_VERSION})", :green)
           copy_file "jquery.js", "public/javascripts/jquery.js"
           copy_file "jquery.min.js", "public/javascripts/jquery.min.js"
-        end
-
-        def copy_jquery_ui
-          if options.ui?
-            say_status("copying", "jQuery UI (#{Jquery::Rails::JQUERY_UI_VERSION})", :green)
-            copy_file "jquery-ui.js", "public/javascripts/jquery-ui.js"
-            copy_file "jquery-ui.min.js", "public/javascripts/jquery-ui.min.js"
-          end
         end
 
         def copy_ujs_driver

--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -5,12 +5,7 @@ module Jquery
     class Railtie < ::Rails::Railtie
       config.before_configuration do
         if config.action_view.javascript_expansions
-          if ::Rails.root.join("public/javascripts/jquery-ui.min.js").exist?
-            jq_defaults = %w(jquery jquery-ui)
-            jq_defaults.map!{|a| a + ".min" } if ::Rails.env.production? || ::Rails.env.test?
-          else
-            jq_defaults = ::Rails.env.production? || ::Rails.env.test? ? %w(jquery.min) : %w(jquery)
-          end
+          jq_defaults = ::Rails.env.production? || ::Rails.env.test? ? %w(jquery.min) : %w(jquery)
 
           # Merge the jQuery scripts, remove the Prototype defaults and finally add 'jquery_ujs'
           # at the end, because load order is important


### PR DESCRIPTION
The README and generator still contain traces of the jQuery UI integration, to the point that the generator currently doesn't work as it refers to `Jquery::Rails::JQUERY_UI_VERSION`. This hopefully removes everything.
