### PR TITLE
Check if config responds_to action_view or not

### DIFF
--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -4,7 +4,7 @@ module Jquery
   module Rails
     class Railtie < ::Rails::Railtie
       config.before_configuration do
-        if config.action_view.javascript_expansions
+        if config.respond_to?('action_view') && config.action_view.javascript_expansions
           jq_defaults = ::Rails.env.production? || ::Rails.env.test? ? %w(jquery.min) : %w(jquery)
 
           # Merge the jQuery scripts, remove the Prototype defaults and finally add 'jquery_ujs'


### PR DESCRIPTION
- On Rails master, config no longer responds_to 'action_view' method.
- Added a check to confirm that
