### PR TITLE
Rails 4 compatibility: require action_view

### DIFF
--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -1,5 +1,7 @@
 # Used to ensure that Rails 3.0.x, as well as Rails >= 3.1 with asset pipeline disabled
 # get the minified version of the scripts included into the layout in production.
+require 'action_view/railtie'
+
 module Jquery
   module Rails
     class Railtie < ::Rails::Railtie


### PR DESCRIPTION
action_view has been divided from actionpack now.
