### PR TITLE
Do not require action_view/railtie

### DIFF
--- a/lib/jquery/rails/railtie.rb
+++ b/lib/jquery/rails/railtie.rb
@@ -1,7 +1,5 @@
 # Used to ensure that Rails 3.0.x, as well as Rails >= 3.1 with asset pipeline disabled
 # get the minified version of the scripts included into the layout in production.
-require 'action_view/railtie'
-
 module Jquery
   module Rails
     class Railtie < ::Rails::Railtie


### PR DESCRIPTION
This reverts commit 6fc528253c453a133bbad8eb72a8e748926e7cc7.

I've fixed it in rails master directly: https://github.com/rails/rails/commit/2e033e2799b83dbe4c01e990554f7e23715301d5

Ref: https://github.com/rails/jquery-rails/pull/143
