### PR TITLE
Allow whitespace before method call in assert_select_jquery

### DIFF
--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -50,7 +50,7 @@ module ActionDispatch
         jquery_opt    = args.first.is_a?(Symbol) ? args.shift : nil
         id            = args.first.is_a?(String) ? args.shift : nil
 
-        pattern = "\\.#{jquery_method || '\\w+'}\\("
+        pattern = "\\s*\\.#{jquery_method || '\\w+'}\\("
         pattern = "#{pattern}['\"]#{jquery_opt}['\"],?\\s*" if jquery_opt
         pattern = "#{pattern}#{PATTERN_HTML}"
         pattern = "(?:jQuery|\\$)\\(['\"]#{id}['\"]\\)#{pattern}" if id


### PR DESCRIPTION
In JavaScript, whitespace is permitted between chained function calls, like so:

``` js
$('#new_subscription')
  .append("<p class=\"message success\"><i class=\"fa fa-check\"></i> You&rsquo;ve been added to the mailing list. Thanks!</p>")
  .find('input[type=email]')
  .val('');
```

The following assertion using `assert_select_jquery` fails on the above example with the latest version of the `jquery-rails` gem:

``` ruby
assert_select_jquery :append, '#new_subscription'
```

The assertion fails because `assert_select_jquery` assumes no whitespace between the jQuery call and the `append` method call.  This pull request modifies the regular expression generated in `assert_select_jquery` to permit legal whitespace.
