### PR TITLE
InstallGenerator takes effect only if config.assets.enabled is exactly false

### DIFF
--- a/lib/generators/jquery/install/install_generator.rb
+++ b/lib/generators/jquery/install/install_generator.rb
@@ -1,7 +1,7 @@
 require 'rails'
 
 # Supply generator for Rails 3.0.x or if asset pipeline is not enabled
-if ::Rails.version < "3.1" || !::Rails.application.config.assets.enabled
+if ::Rails.version < "3.1" || ::Rails.application.config.assets.enabled == false
   module Jquery
     module Generators
       class InstallGenerator < ::Rails::Generators::Base


### PR DESCRIPTION
Because config.assets.enabled is implicitly true in Rails 4.0+.