### PR TITLE
buttonClickSelector must have data-url attribute

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -25,7 +25,7 @@
     linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote], a[data-disable-with], a[data-disable]',
 
     // Button elements bound by jquery-ujs
-    buttonClickSelector: 'button[data-remote], button[data-confirm]',
+    buttonClickSelector: 'button[data-remote], button[data-url][data-confirm]',
 
     // Select elements bound by jquery-ujs
     inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',


### PR DESCRIPTION
If no data url button which is like a form child button, it'll failure to fire correct handler.
Perhaps, "button[data-confirm]" is support for button which has no form parent.

So, I fixed the behavior.

Following example, button tag is not "buttonClickSelector".

```
<form action="/purchase" method="post">
  <input type="hidden" value="item_id_or_something">
  <button data-confirm="are you ready?">
</form>
```

Following example, button tag is "buttonClickSelector".

```
// this button is not form child
<button data-confirm="are you ready?" data-url="/purchase", data-method="post">
```
