### PR TITLE
Remove rubyforge_project option

### DIFF
--- a/jquery-rails.gemspec
+++ b/jquery-rails.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "jquery-rails"
 
   s.add_dependency "railties", ">= 4.2.0"
   s.add_dependency "thor",     ">= 0.14", "< 2.0"


### PR DESCRIPTION
rubyforge_project option is obsoleted.