### PR TITLE
Fixes #200 based on the behavior of IE7 and IE compatibility modes

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -176,10 +176,13 @@
         // This is a workaround to a IE bug.
         urlAnchor.href = urlAnchor.href;
 
-        // Make sure that the browser parses the URL and that the protocols and hosts match.
-        return !urlAnchor.protocol || !urlAnchor.host ||
-          (originAnchor.protocol + "//" + originAnchor.host !==
-            urlAnchor.protocol + "//" + urlAnchor.host);
+	// If URL protocol *and* host are false, assume it is not a
+	// cross-domain request (should only be the case for IE7 and IE
+	// compatibility mode).  Otherwise, evaluate protocol and host of the
+	// URL against the origin protocol and host
+        return !((!urlAnchor.protocol && !urlAnchor.host) ||
+		 (originAnchor.protocol + "//" + originAnchor.host ===
+		  urlAnchor.protocol + "//" + urlAnchor.host));
       } catch (e) {
         // If there is an error parsing the URL, assume it is crossDomain.
         return true;


### PR DESCRIPTION
The logic has been changed such that if the URL has not been fully qualified to include protocol and host (which a problem with IE7 and IE in compatibility mode), assume that the request is not cross-domain.