### PR TITLE
Allow rails-dom-testing 2

### DIFF
--- a/jquery-rails.gemspec
+++ b/jquery-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "railties", ">= 4.2.0"
   s.add_dependency "thor",     ">= 0.14", "< 2.0"
 
-  s.add_dependency "rails-dom-testing", "~> 1.0"
+  s.add_dependency "rails-dom-testing", ">= 1", "< 3"
 
   s.files        = `git ls-files`.split("\n")
   s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
If users are running rails-dom-testing via a GitHub entry, Bundler can't find compatible releases for it
and jquery-rails.

Fix by allowing version 2, but also restrict any version 3 as a safety measure.