### PR TITLE
corrected the jquery versions in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.1.0
 
-- Update jQuery to 1.12.0 and 2.2.0
+- Update jQuery to 1.12.1 and 2.2.1
 - Update jquery-ujs to 1.2.0
 
 ## 4.0.5


### PR DESCRIPTION
I believe there was a quick bump in the jQuery versions. But the CHANGELOG still has old version names in it. So changed it to reflect the latest upgrades for jQuery.