### PR TITLE
Fix tests on TravisCI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rails', group: :test
+gem 'rack', '~>1.6', group: :test
+gem "mime-types", "< 3", group: :test
 
 # Specify your gem's dependencies in jquery-rails.gemspec
 gemspec


### PR DESCRIPTION
Rack requires at least ruby 2.2.2.
This fixes the TravisCI errors.