### PR TITLE
Add possibility to test HTML attribute selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.2
+
+- Add possibility to test HTML attribute selectors
+
 ## 4.2.1
 
 - Update jQuery to 3.1.0

--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -56,7 +56,7 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
     jquery_opt    = args.first.is_a?(Symbol) ? args.shift : nil
     id            = args.first.is_a?(String) ? escape_id(args.shift) : nil
 
-    target_pattern   = "['\"\\[]#{id || '.*'}['\"\\]]"
+    target_pattern   = "['\"]#{id || '.*'}['\"]"
     method_pattern   = "#{jquery_method || '\\w+'}"
     argument_pattern = jquery_opt ? "['\"]#{jquery_opt}['\"].*" : PATTERN_HTML
 

--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -54,9 +54,9 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
   def assert_select_jquery(*args, &block)
     jquery_method = args.first.is_a?(Symbol) ? args.shift : nil
     jquery_opt    = args.first.is_a?(Symbol) ? args.shift : nil
-    id            = args.first.is_a?(String) ? args.shift : nil
+    id            = args.first.is_a?(String) ? escape_id(args.shift) : nil
 
-    target_pattern   = "['\"]#{id || '.*'}['\"]"
+    target_pattern   = "['\"\\[]#{id || '.*'}['\"\\]]"
     method_pattern   = "#{jquery_method || '\\w+'}"
     argument_pattern = jquery_opt ? "['\"]#{jquery_opt}['\"].*" : PATTERN_HTML
 
@@ -127,5 +127,14 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
       # js encodes non-ascii characters.
       unescaped.gsub!(PATTERN_UNICODE_ESCAPED_CHAR) {|u| [$1.hex].pack('U*')}
       unescaped
+    end
+
+    def escape_id(selector)
+      return unless selector
+
+      id = selector.gsub('[', '\[')
+      id.gsub!(']', '\]')
+
+      id
     end
 end

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -13,6 +13,7 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
     jQuery("<div><p>something</p></div>").prependTo("#id");
     $('#id').remove();
     jQuery("#id").hide();
+    $("[data-placeholder~=name]").remove();
   JS
 
   setup do
@@ -28,6 +29,7 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
       assert_select_jquery :replaceWith, '#id' do
         assert_select 'p', 'something'
       end
+      assert_select_jquery :remove, "[data-placeholder~=name]"
     end
 
     assert_raise Minitest::Assertion, "No JQuery call matches [:show, :some_wrong]" do


### PR DESCRIPTION
Previously it wasn't possible to test something like this:

```ruby
assert_select_jquery :remove, "[data-placeholder~=name]"
```

This commit fixes it by escaping `[` and `]` characters in the selector.