### PR TITLE
Fix bug with single quoted escaped html

### DIFF
--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -47,7 +47,7 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
   #   assert_select '.product'
   # end
 
-  PATTERN_HTML  = "['\"]((\\\\\"|[^\"])*)['\"]"
+  PATTERN_HTML  = "['\"]((\\\\\"|\\\\'|[^\"'])*)['\"]"
   PATTERN_UNICODE_ESCAPED_CHAR = /\\u([0-9a-zA-Z]{4})/
   SKELETAL_PATTERN = "(?:jQuery|\\$)\\(%s\\)\\.%s\\(%s\\);"
 

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -8,6 +8,7 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
   JAVASCRIPT_TEST_OUTPUT = <<-JS
     $("#card").show("blind", 1000);
     $("#id").html('<div><p>something</p></div>');
+    $('#card').html('<div><p>something else</p></div>');
     jQuery("#id").replaceWith("<div><p>something</p></div>");
     $("<div><p>something</p></div>").appendTo("#id");
     jQuery("<div><p>something</p></div>").prependTo("#id");
@@ -34,6 +35,12 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
 
     assert_raise Minitest::Assertion, "No JQuery call matches [:show, :some_wrong]" do
       assert_select_jquery :show, :some_wrong
+    end
+
+    assert_raise Minitest::Assertion, "<something else> was expected but was <something>" do
+      assert_select_jquery :html, '#id' do
+        assert_select 'p', 'something else'
+      end
     end
   end
 


### PR DESCRIPTION
When using single quoted string the Regexp will match outside of the string spanning through many lines of JS code until it finds a double quote. This might cause false positives when you `assert_select` inside the block passed to `assert_select_jquery` because you can assert positively any text found in the mismatched Regexp even if not found inside the expected string.