### PR TITLE
Add support for multiple matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fix matching mutiple calls for the same selector/function exception
+
 ## 4.3.1
 
 - update jquery to 3.2.1

--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -91,14 +91,14 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
 
     if block_given?
       @selected ||= nil
-      fragments = Nokogiri::HTML::Document.new
+      fragments = Nokogiri::HTML::Document.new.fragment
 
       if matched_pattern
         response.body.scan(Regexp.new(matched_pattern)).each do |match|
           flunk 'This function can\'t have HTML argument' if match.is_a?(String)
 
-          doc = Nokogiri::HTML::Document.parse(unescape_js(match.first))
-          doc.root.children.each do |child|
+          doc = Nokogiri::HTML::DocumentFragment.parse(unescape_js(match.first))
+          doc.children.each do |child|
             fragments << child if child.element?
           end
         end

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -10,6 +10,7 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
     $("#id").html('<div><p>something</p></div>');
     jQuery("#id").replaceWith("<div><p>something</p></div>");
     $("<div><p>something</p></div>").appendTo("#id");
+    $("<div><p>something else</p></div>").appendTo("#id");
     jQuery("<div><p>something</p></div>").prependTo("#id");
     $('#id').remove();
     jQuery("#id").hide();
@@ -41,6 +42,7 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
     assert_nothing_raised do
       assert_select_jquery :appendTo, '#id' do
         assert_select 'p', 'something'
+        assert_select 'p', 'something else'
       end
       assert_select_jquery :prependTo, '#id' do
         assert_select 'p', 'something'


### PR DESCRIPTION
In theory the `assert_jquery_method` supports multiple matches for the same selector/function. But this was not working because of how Nokogiri was used. The algorithm was trying to add a tag as a root HTML element multiple times raising the "Document already has a root node" error.

At the beginning I tried to fix the code so that we add the actually parsed children to the html/body tag but then I preferred to use the more flexible fragments.