### PR TITLE
Add support for nested jquery assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Allow jQuery calls assertion within nested callbacks
 - Add possibility to test HTML: all, attribute prefix, attribute contains,
   attribute ends with, child, and class selectors
 - Fix matching mutiple calls for the same selector/function exception

--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -61,6 +61,8 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
   SKELETAL_PATTERN = "(?:jQuery|\\$)\\(%s\\)\\.%s\\(%s\\);"
 
   def assert_select_jquery(*args, &block)
+    @selected ||= response.body
+
     jquery_method = args.first.is_a?(Symbol) ? args.shift : nil
     jquery_opt    = args.first.is_a?(Symbol) ? args.shift : nil
     id            = args.first.is_a?(String) ? escape_id(args.shift) : nil
@@ -88,7 +90,7 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
 
     matched_pattern = nil
     patterns.each do |pattern|
-      if response.body.match(Regexp.new(pattern))
+      if @selected.match(Regexp.new(pattern))
         matched_pattern = pattern
         break
       end
@@ -100,11 +102,9 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
     end
 
     if block_given?
-      @selected ||= nil
-
       if jquery_opt
         code_blocks = []
-        response.body.scan(Regexp.new(matched_pattern)).each do |match|
+        @selected.scan(Regexp.new(matched_pattern)).each do |match|
           flunk 'This function can\'t have a callback' if match.first.nil?
           code_blocks << match.first
         end
@@ -114,7 +114,7 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
         fragments = Nokogiri::HTML::Document.new.fragment
 
         if matched_pattern
-          response.body.scan(Regexp.new(matched_pattern)).each do |match|
+          @selected.scan(Regexp.new(matched_pattern)).each do |match|
             flunk 'This function can\'t have HTML argument' if match.is_a?(String)
 
             doc = Nokogiri::HTML::DocumentFragment.parse(unescape_js(match.first))

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -52,7 +52,6 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
       assert_select_jquery :hide, :bounce, '#card' do
         # assert multiple jquery calls within different callbacks
         assert_select_jquery :html, '#content' do
-          assert_select 'p', 'something'
           assert_select 'p', 'animating hide'
         end
 
@@ -67,6 +66,15 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
 
     assert_raise Minitest::Assertion, "No JQuery call matches [:show, :some_wrong]" do
       assert_select_jquery :show, :some_wrong
+    end
+
+    assert_raise Minitest::Assertion, "<something> expected but was <animating hide>" do
+      # assure false positives are prevented
+      assert_select_jquery :hide, :bounce, '#card' do
+        assert_select_jquery :html, '#content' do
+          assert_select 'p', 'something'
+        end
+      end
     end
 
     assert_raise Minitest::Assertion, "<something else> was expected but was <something>" do

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -1,6 +1,5 @@
 require_relative 'test_helper'
 require_relative '../lib/jquery/assert_select'
-
 class AssertSelectJQueryTest < ActiveSupport::TestCase
   include Rails::Dom::Testing::Assertions::SelectorAssertions
   attr_reader :response
@@ -19,6 +18,16 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
     $("#cart tr:not(.total_line) > *").remove();
     $("[href|=\"val\"][href$=\"val\"][href^=\"val\"]").remove();
     $("tr + td, li").remove();
+    $("#card").hide("blind", 100, function() {
+      $("#content").html('<div><p>something</p></div>');
+    });
+    $("#card").hide("bounce", 100, function() {
+      $("#content").html('<div><p>animating hide</p></div>');
+
+      $("#card").show("bounce", 100, function() {
+        $("#content").html('<div><p>animating show</p></div>');
+      });
+    });
   JS
 
   setup do
@@ -38,6 +47,22 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
       assert_select_jquery :remove, "#cart tr:not(.total_line) > *"
       assert_select_jquery :remove, "[href|=\"val\"][href$=\"val\"][href^=\"val\"]"
       assert_select_jquery :remove, "tr + td, li"
+
+      # These allow to assert correct execution order in addition to simple execution assertion
+      assert_select_jquery :hide, :bounce, '#card' do
+        # assert multiple jquery calls within different callbacks
+        assert_select_jquery :html, '#content' do
+          assert_select 'p', 'something'
+          assert_select 'p', 'animating hide'
+        end
+
+        # assert callback-nested jquery calls
+        assert_select_jquery :show, :bounce, '#card' do
+          assert_select_jquery :html, '#content' do
+            assert_select 'p', 'animating show'
+          end
+        end
+      end
     end
 
     assert_raise Minitest::Assertion, "No JQuery call matches [:show, :some_wrong]" do
@@ -48,6 +73,10 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
       assert_select_jquery :html, '#id' do
         assert_select 'p', 'something else'
       end
+    end
+
+    assert_raise Minitest::Assertion, "This function can't have a callback" do
+      assert_select_jquery(:show, :blind, '#card') { }
     end
   end
 
@@ -71,6 +100,10 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
     assert_nothing_raised do
       assert_select_jquery :remove
       assert_select_jquery :hide
+    end
+
+    assert_raise Minitest::Assertion, "This function can't have HTML argument" do
+      assert_select_jquery(:remove) { }
     end
 
     assert_raise Minitest::Assertion, 'No JQuery call matches [:wrong_function]' do


### PR DESCRIPTION
At first I just wanted to make `assert_select_jquery(:hide, :blind, '#card')` support:

```javascript
$('#cart').hide('blind', function() {
  $('#id').html('<p>html</p>');
});
```

But then I realized I could also use this kind of assertion to also `assert_select_jquery(:html, '#id')` from within the original assertion, and thus asserting not only that the expression are being called but also that they are being called in the right async sequence.

```ruby
assert_select_jquery(:hide, :blind, '#card') do
  assert_select_jquery(:html, '#id') do
    assert_select('p', 'html')
  end
end
```