### PR TITLE
Add small explanation about how to install for Rails 5.1 and up

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ The jquery and jquery-ujs files will be added to the asset pipeline and availabl
 //= require jquery_ujs
 ```
 
+If you are running Rails 5.1 and up, `jquery_ujs` is not needed anymore and you can just add:
+
+```js
+//= require jquery
+```
+
 If you want to use jQuery 2, you can require `jquery2` instead:
 
 ```js


### PR DESCRIPTION
It's kind of unclear if we should keep `//= require rails-ujs` or `//= require jquery-ujs`. I would suppose advising for `//= require rails-ujs` would be the better path as more people will use it and would be probably more stable?