### PR TITLE
Update README.md: Link to jQuery and Rails on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jquery-rails
 
-jQuery! For Rails! So great.
+[jQuery](https://github.com/jquery/jquery)! For [Rails](https://github.com/rails/rails)! So great.
 
 This gem provides:
 


### PR DESCRIPTION
Hey :wave: Just came to the repo main page from a DepFu PR and then wanted to jump over to jQuery repo itself, to check their changelog. So, lazy as I am I wanted to click a [jQuery](https://github.com/jquery/jquery) link but there was none. Now there is. And [Rails](https://github.com/rails/rails) too! So great.