### PR TITLE
Fix `unescape_js` to match changes in Action View

### DIFF
--- a/lib/jquery/assert_select.rb
+++ b/lib/jquery/assert_select.rb
@@ -124,6 +124,8 @@ module Rails::Dom::Testing::Assertions::SelectorAssertions
       unescaped.gsub!('\n', "\n")
       unescaped.gsub!('\076', '>')
       unescaped.gsub!('\074', '<')
+      unescaped.gsub!(/\\\$/, '$')
+      unescaped.gsub!(/\\`/, '`')
       # js encodes non-ascii characters.
       unescaped.gsub!(PATTERN_UNICODE_ESCAPED_CHAR) {|u| [$1.hex].pack('U*')}
       unescaped

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -23,6 +23,8 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
 
     // without semicolon
     $("#browser_cart").hide("blind", 1000)
+
+    $('#item').html('<div><span>\\`Total\\`: \\$12.34</span></div>');
   JS
 
   setup do
@@ -43,6 +45,10 @@ class AssertSelectJQueryTest < ActiveSupport::TestCase
       assert_select_jquery :remove, "#cart tr:not(.total_line) > *"
       assert_select_jquery :remove, "[href|=\"val\"][href$=\"val\"][href^=\"val\"]"
       assert_select_jquery :remove, "tr + td, li"
+
+      assert_select_jquery :html, '#item' do
+        assert_select 'span', '`Total`: $12.34'
+      end
     end
 
     assert_raise Minitest::Assertion, "No JQuery call matches [:show, :some_wrong]" do


### PR DESCRIPTION
Unescapes dollar signs and backticks added by rails/rails@033a738817abd6e446e1b320cb7d1a5c15224e9a