### PR TITLE
Drop `git` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+require:
+  - rubocop-packaging
+
+AllCops:
+  TargetRubyVersion: 2.5
+  DisabledByDefault: true
+
+Packaging/BundlerSetupInTests:
+  Enabled: true
+
+Packaging/GemspecGit:
+  Enabled: true
+
+Packaging/RequireHardcodingLib:
+  Enabled: true
+
+Packaging/RequireRelativeHardcodingLib:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -18,5 +18,9 @@ else
   gem 'nokogiri', '~> 1.6.0'
 end
 
+if RUBY_VERSION >= '2.4'
+  gem 'rubocop-packaging', '~> 0.5'
+end
+
 # Specify your gem's dependencies in jquery-rails.gemspec
 gemspec

--- a/jquery-rails.gemspec
+++ b/jquery-rails.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails-dom-testing", ">= 1", "< 3"
 
-  s.files        = `git ls-files`.split("\n")
-  s.executables  = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files        = Dir["{lib,vendor}/**/*", "CHANGELOG.md", "MIT-LICENSE", "README.md", "VERSIONS.md"]
   s.require_path = 'lib'
 end

--- a/test/assert_select_jquery_test.rb
+++ b/test/assert_select_jquery_test.rb
@@ -1,6 +1,6 @@
 require 'ostruct'
+require 'jquery/assert_select'
 require_relative 'test_helper'
-require_relative '../lib/jquery/assert_select'
 
 class AssertSelectJQueryTest < ActiveSupport::TestCase
   include Rails::Dom::Testing::Assertions::SelectorAssertions


### PR DESCRIPTION
Hi @carlosantoniodasilva 👋🏻

As discussed in #278, here's the PR, fixing that!
It also adds the `Packaging` extension so that it helps the downstream maintainers 💫 

Hope this is good to go! Please let me know if you want me to expand on anything! 😄 

Closes: #278 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>