### PR TITLE
JQMIGRATE: jQuery.fn.submit() event shorthand is deprecated #299

### DIFF
--- a/vendor/assets/javascripts/jquery_ujs.js
+++ b/vendor/assets/javascripts/jquery_ujs.js
@@ -228,7 +228,7 @@
       if (target) { form.attr('target', target); }
 
       form.hide().append(metadataInput).appendTo('body');
-      form.submit();
+      form.trigger('submit');
     },
 
     // Helper function that returns form elements that match the specified CSS selector


### PR DESCRIPTION
Use trigger('submit') instead of .submit which is deprecated.